### PR TITLE
fix: show multiple missing sha per workflow file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,7 @@ async function run() {
           jobHasError = runAssertions(uses, allowlist, isDryRun);
         } else if (steps !== undefined) {
           for (const step of steps) {
-            if (!jobHasError) {
-              jobHasError = runAssertions(step['uses'], allowlist, isDryRun);
-            }
+            jobHasError = runAssertions(step['uses'], allowlist, isDryRun);
           }
         } else {
           core.warning(`The "${job}" job of the "${basename}" workflow does not contain uses or steps.`);  


### PR DESCRIPTION
Previously only showed one problem per file

fixes zgosalvez/github-actions-ensure-sha-pinned-actions#162