### PR TITLE
Potential fix for code scanning alert no. 17: Shell command built from environment values

### DIFF
--- a/test/pass.test.js
+++ b/test/pass.test.js
@@ -1,5 +1,5 @@
 const process = require('process');
-const {execSync} = require('child_process');
+const {execFileSync} = require('child_process');
 const jest = require('@jest/globals');
 const path = require('path');
 
@@ -24,7 +24,7 @@ jest.test('actions pass', () => {
     let result;
 
     try {
-        throw execSync(`${process.execPath} ${ip}`, { env: process.env }).toString();
+        throw execFileSync(process.execPath, [ip], { env: process.env }).toString();
     } catch (error) {
         result = (error.stdout || error).toString();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/security/code-scanning/17](https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/security/code-scanning/17)

Use a non-shell execution API so the executable and arguments are passed separately and never interpreted by a shell.

Best fix here: replace `execSync(`${process.execPath} ${ip}`, { env: process.env })` with `execFileSync(process.execPath, [ip], { env: process.env })`, and update the import from `execSync` to `execFileSync`. This preserves behavior (running Node on `ip` with the same environment and capturing output) while removing shell interpretation risk and addressing both alert variants at once.

Edit only `test/pass.test.js`:
- Update `child_process` import to destructure `execFileSync`.
- Update line 27 call site accordingly.

No other functional changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
